### PR TITLE
Allow to ignore presentation indicator of outgoing calls [1/3]

### DIFF
--- a/api/cm_current.txt
+++ b/api/cm_current.txt
@@ -808,6 +808,7 @@ package cyanogenmod.providers {
     field public static final java.lang.String CAMERA_LAUNCH = "camera_launch";
     field public static final java.lang.String CAMERA_SLEEP_ON_RELEASE = "camera_sleep_on_release";
     field public static final java.lang.String CAMERA_WAKE_SCREEN = "camera_wake_screen";
+    field public static final java.lang.String CONNECTED_LINE_IDENTIFICATION = "connected_line_identification";
     field public static final android.net.Uri CONTENT_URI;
     field public static final java.lang.String DIALER_OPENCNAM_ACCOUNT_SID = "dialer_opencnam_account_sid";
     field public static final java.lang.String DIALER_OPENCNAM_AUTH_TOKEN = "dialer_opencnam_auth_token";

--- a/packages/CMSettingsProvider/res/values/defaults.xml
+++ b/packages/CMSettingsProvider/res/values/defaults.xml
@@ -107,4 +107,7 @@
     <!-- Default values for protected component managers -->
     <string name="def_protected_component_managers" translatable="false">com.android.settings|com.android.launcher3|com.cyanogenmod.trebuchet</string>
 
+    <!-- Default value for COLP -->
+    <bool name="def_connected_line_identification">true</bool>
+
 </resources>

--- a/packages/CMSettingsProvider/src/org/cyanogenmod/cmsettings/CMDatabaseHelper.java
+++ b/packages/CMSettingsProvider/src/org/cyanogenmod/cmsettings/CMDatabaseHelper.java
@@ -299,6 +299,9 @@ public class CMDatabaseHelper extends SQLiteOpenHelper{
             loadIntegerSetting(stmt, CMSettings.System.STATUS_BAR_BATTERY_STYLE,
                     R.integer.def_battery_style);
 
+            loadBooleanSetting(stmt, CMSettings.System.CONNECTED_LINE_IDENTIFICATION,
+                    R.bool.def_connected_line_identification);
+
             if (mContext.getResources().getBoolean(R.bool.def_notification_pulse_custom_enable)) {
                 loadStringSetting(stmt, CMSettings.System.NOTIFICATION_LIGHT_PULSE_CUSTOM_VALUES,
                         R.string.def_notification_pulse_custom_value);

--- a/packages/CMSettingsProvider/tests/src/org/cyanogenmod/cmsettings/tests/CMSettingsProviderDefaultsTest.java
+++ b/packages/CMSettingsProvider/tests/src/org/cyanogenmod/cmsettings/tests/CMSettingsProviderDefaultsTest.java
@@ -76,6 +76,9 @@ public class CMSettingsProviderDefaultsTest extends AndroidTestCase {
         SYSTEM_SETTINGS_DEFAULTS.add(new Setting(
                 CMSettings.System.STATUS_BAR_BATTERY_STYLE,
                 "R.integer.def_battery_style"));
+        SYSTEM_SETTINGS_DEFAULTS.add(new Setting(
+                CMSettings.System.CONNECTED_LINE_IDENTIFICATION,
+                "R.bool.def_connected_line_identification"));
     }
 
     //SECURE

--- a/src/java/cyanogenmod/providers/CMSettings.java
+++ b/src/java/cyanogenmod/providers/CMSettings.java
@@ -1761,6 +1761,16 @@ public final class CMSettings {
                 sBooleanValidator;
 
         /**
+         * Whether or not to respect the network presentation indicator of outgoing calls
+         */
+        public static final String CONNECTED_LINE_IDENTIFICATION =
+                "connected_line_identification";
+
+        /** @hide */
+        public static final Validator CONNECTED_LINE_IDENTIFICATION_VALIDATOR =
+                sBooleanValidator;
+
+        /**
          * I can haz more bukkits
          * @hide
          */
@@ -2015,6 +2025,8 @@ public final class CMSettings {
             VALIDATORS.put(ZEN_PRIORITY_ALLOW_LIGHTS, ZEN_PRIORITY_ALLOW_LIGHTS_VALIDATOR);
             VALIDATORS.put(TOUCHSCREEN_GESTURE_HAPTIC_FEEDBACK,
                     TOUCHSCREEN_GESTURE_HAPTIC_FEEDBACK_VALIDATOR);
+            VALIDATORS.put(CONNECTED_LINE_IDENTIFICATION,
+                    CONNECTED_LINE_IDENTIFICATION_VALIDATOR);
             VALIDATORS.put(__MAGICAL_TEST_PASSING_ENABLER,
                     __MAGICAL_TEST_PASSING_ENABLER_VALIDATOR);
         };

--- a/system-api/cm_system-current.txt
+++ b/system-api/cm_system-current.txt
@@ -808,6 +808,7 @@ package cyanogenmod.providers {
     field public static final java.lang.String CAMERA_LAUNCH = "camera_launch";
     field public static final java.lang.String CAMERA_SLEEP_ON_RELEASE = "camera_sleep_on_release";
     field public static final java.lang.String CAMERA_WAKE_SCREEN = "camera_wake_screen";
+    field public static final java.lang.String CONNECTED_LINE_IDENTIFICATION = "connected_line_identification";
     field public static final android.net.Uri CONTENT_URI;
     field public static final java.lang.String DIALER_OPENCNAM_ACCOUNT_SID = "dialer_opencnam_account_sid";
     field public static final java.lang.String DIALER_OPENCNAM_AUTH_TOKEN = "dialer_opencnam_auth_token";


### PR DESCRIPTION
With some mobile network operators, the presentation indicator of
outgoing calls is always set to either "unknown" or "restricted".
As consequence, the dialed number doesn't show up in clear in the
call history. Allow to ignore the presentation indicator of outgoing
calls to never hide the dialed numbers.

Change-Id: Ia7b9fef3a929e512d8ecb704204b36e3836a056b
