### PR TITLE
Expose lock screen blurring as a setting [1/2]

### DIFF
--- a/sdk/src/java/cyanogenmod/providers/CMSettings.java
+++ b/sdk/src/java/cyanogenmod/providers/CMSettings.java
@@ -2780,6 +2780,13 @@ public final class CMSettings {
          */
         public static final String CM_SETUP_WIZARD_COMPLETED = "cm_setup_wizard_completed";
 
+        /**
+         * Whether lock screen bluring is enabled on devices that support this feature
+         * @hide
+         */
+        public static final String LOCK_SCREEN_BLUR_ENABLED = "lock_screen_blur_enabled";
+
+
         // endregion
 
         /**


### PR DESCRIPTION
This will provide control over blurring since the current implementation
assumes it is always on provided the device config specifies it
supports blur.

Change-Id: I71e318af12b5212133c6c5b02bed050eb67757d9
TICKET: CYNGNOS-2610
