### PR TITLE
cmsdk: Correct the useSegmentedBatteryLed details

### DIFF
--- a/cm/res/res/values/config.xml
+++ b/cm/res/res/values/config.xml
@@ -70,7 +70,7 @@
          Used to decide if the user can change the multiple LEDs settings -->
     <bool name="config_multipleNotificationLeds">false</bool>
 
-    <!-- Should we send the battery level to the HAL as the lower 8 bits
+    <!-- Should we send the battery level to the HAL as the alpha channel
          of the color?  This should only be used if the HAL does special
          handling of the value- a use case for this would be a segmented
          LED that can function as a range bar -->


### PR DESCRIPTION
- The power level is passed down as the alpha channel now,
  in order to preserve consistency and still pass down
  the color of the battery lights given to the liblights

Change-Id: Ia44cf1f73f09da6c96ac3b98e9387f1e3ec42249
